### PR TITLE
Add upComingSession info

### DIFF
--- a/src/pages/GenerateCalendar.jsx
+++ b/src/pages/GenerateCalendar.jsx
@@ -29,6 +29,7 @@ const GenerateCalendar = () => {
   const [fullDayEvents, setFullDayEvents] = useState([]);
   const [decisions, setDecisions] = useState([]);
   const [studyPlan, setStudyPlan] = useState(null);
+  const [upComingSession, setUpComingSession] = useState(null);
 
   const { subjectID, isAuthenticated, isAuthLoading, clearUserState } =
     useContext(UserContext);
@@ -59,6 +60,7 @@ const GenerateCalendar = () => {
         console.log(response.data);
 
         setStudyPlan(response.data.studyPlan);
+        setUpComingSession(response.data.upComingSession);
       } catch (error) {
         console.error(error);
         setStudyPlan(null);
@@ -451,7 +453,20 @@ const GenerateCalendar = () => {
           <Card className="card-container generate-plan-card">
             <Card.Body>
               <Card.Title>Upcoming Study Session:</Card.Title>
-              <Card.Text></Card.Text>
+              {upComingSession ? (
+                <>
+                  <h6 className="mb-0 title-in-preferences">Course Name:</h6>
+                  <p>{upComingSession.courseName}</p>
+                  <h6 className="mb-0 title-in-preferences">Description:</h6>
+                  <p>{upComingSession.description}</p>
+                  <h6 className="mb-0 title-in-preferences">Start Time:</h6>
+                  <p>{new Date(upComingSession.startTime).toLocaleString()}</p>
+                  <h6 className="mb-0 title-in-preferences">End Time:</h6>
+                  <p>{new Date(upComingSession.endTime).toLocaleString()}</p>
+                </>
+              ) : (
+                <div>There are no sessions yet.</div>
+              )}
             </Card.Body>
           </Card>
         </Col>

--- a/src/pages/GenerateCalendar.jsx
+++ b/src/pages/GenerateCalendar.jsx
@@ -457,7 +457,7 @@ const GenerateCalendar = () => {
                 <>
                   <h6 className="mb-0 title-in-preferences">Course Name:</h6>
                   <p>{upComingSession.courseName}</p>
-                  <h6 className="mb-0 title-in-preferences">Description:</h6>
+                  <h6 className="mb-0 title-in-preferences">Subject:</h6>
                   <p>{upComingSession.description}</p>
                   <h6 className="mb-0 title-in-preferences">Start Time:</h6>
                   <p>{new Date(upComingSession.startTime).toLocaleString()}</p>


### PR DESCRIPTION
## Description
#### I added the logic needed for the upcomig session card to be printed in the generate calendar page.
#### you can look at generateCalendar.js page and see that the cahnges i did can be summerized to:
#### 1. add state for upComingSession with init value of null.
#### 2. when accessing the backend i set the session value to the return value from backend.
#### 3. in the return section i got inpired by ChatGPT and wrote the section completly myself printing the session if it's not a null otherwise printing static message

## Relevent Issues:
#### Resolves #31 