### PR TITLE
Refactor google-client-id to be injected from .env file

### DIFF
--- a/src/__test__/App.test.jsx
+++ b/src/__test__/App.test.jsx
@@ -4,10 +4,12 @@ import "@testing-library/jest-dom/extend-expect";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import App from "../App.jsx";
 
+const google_client_id = import.meta.env.VITE_GOOGLE_CLIENT_ID
+
 test("renders navbar links and buttons", () => {
     render(
         <React.StrictMode>
-            <GoogleOAuthProvider clientId="455740199105-no6hntm3m4aknhjpidr52ms8ti2vib49.apps.googleusercontent.com">
+            <GoogleOAuthProvider clientId={google_client_id}>
                 <App />
             </GoogleOAuthProvider>
         </React.StrictMode>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,9 +4,11 @@ import App from "./App";
 import "./index.css";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 
+const google_client_id = import.meta.env.VITE_GOOGLE_CLIENT_ID
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <GoogleOAuthProvider clientId="455740199105-no6hntm3m4aknhjpidr52ms8ti2vib49.apps.googleusercontent.com">
+    <GoogleOAuthProvider clientId={google_client_id}>
       <App />
     </GoogleOAuthProvider>
   </React.StrictMode>


### PR DESCRIPTION
Added .env file that will encapsulate the google-client-id

close #36 