### PR TITLE
Fix upcoming study session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+/.env

--- a/src/components/RegularEventItem.jsx
+++ b/src/components/RegularEventItem.jsx
@@ -69,7 +69,7 @@ function RegularEventItem({eventSummery, eventDescription, startTime, endTime}) 
             <Col style={{flexGrow: 0}}>
                 <Box
                     sx={{
-                        backgroundColor: 'primary.dark'
+                        backgroundColor: '#4279d1'
                     }}
                     style={{width: "4px", height: "100%"}}
                 />

--- a/src/components/RegularEventItem.jsx
+++ b/src/components/RegularEventItem.jsx
@@ -1,0 +1,91 @@
+import React from "react";
+import ListGroup from "react-bootstrap/ListGroup";
+import {Col, Row} from "react-bootstrap";
+import Box from "@mui/material/Box";
+
+function EventDateTime({startTime, endTime}) {
+    const dateOfStartTime = new Date(startTime.value);
+    const dateOfEndTime = new Date(endTime.value);
+
+    return (<>
+        {dateOfStartTime.toLocaleDateString() !== dateOfEndTime.toLocaleDateString() ? (
+            <div
+                className="sub-text">{dateOfStartTime.toLocaleString()} - {dateOfEndTime.toLocaleString('he-IL', {
+                hour12: false,
+                hour: '2-digit',
+                minute: '2-digit'
+            })}
+            </div>
+        ) : (
+            <div
+                className="sub-text"> {dateOfStartTime.toLocaleDateString()}, {dateOfStartTime.toLocaleTimeString('he-IL', {
+                hour12: false,
+                hour: '2-digit',
+                minute: '2-digit'
+            })}-{dateOfEndTime.toLocaleTimeString('he-IL', {
+                hour12: false,
+                hour: '2-digit',
+                minute: '2-digit'
+            })}
+            </div>
+        )
+        }
+    </>);
+}
+
+function NumberOfDaysAway({eventDate}) {
+    const currentDate = new Date();
+
+    currentDate.setHours(0, 0, 0, 0);
+    eventDate.setHours(0, 0, 0, 0);
+
+    // To calculate the time difference of two dates
+    const Difference_In_Time = eventDate.getTime() - currentDate.getTime();
+
+    // To calculate the no. of days between two dates
+    const Difference_In_Days = Math.ceil(Difference_In_Time / (1000 * 3600 * 24));
+
+
+    return (<> {Difference_In_Days === 0 ? (
+        <div className="sub-text">Today</div>
+    ) : (Difference_In_Days === 1 ? (
+            <div className="sub-text">Tomorrow</div>
+        ) : (
+            <div style={{textAlign: "center"}}>
+                <div className="sub-text">{Difference_In_Days}</div>
+                <div className="sub-text"> days away</div>
+            </div>
+
+        )
+    )
+    }
+    </>);
+}
+
+
+function RegularEventItem({eventSummery, eventDescription, startTime, endTime}) {
+    return (
+        <Row>
+            <Col style={{flexGrow: 0}}>
+                <Box
+                    sx={{
+                        backgroundColor: 'primary.dark'
+                    }}
+                    style={{width: "4px", height: "100%"}}
+                />
+            </Col>
+            <Col>
+                <div className="mb-0 title-in-preferences">{eventSummery}</div>
+                <EventDateTime startTime={startTime} endTime={endTime}></EventDateTime>
+                <div>Subjects: {eventDescription}</div>
+            </Col>
+            <Col style={{maxWidth: "fit-content"}}>
+                <NumberOfDaysAway eventDate={new Date(startTime.value)}></NumberOfDaysAway>
+            </Col>
+        </Row>
+
+
+    );
+}
+
+export default RegularEventItem;

--- a/src/components/RegularEventItem.jsx
+++ b/src/components/RegularEventItem.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import ListGroup from "react-bootstrap/ListGroup";
 import {Col, Row} from "react-bootstrap";
 import Box from "@mui/material/Box";
 
@@ -63,13 +62,15 @@ function NumberOfDaysAway({eventDate}) {
 }
 
 
-function RegularEventItem({eventSummery, eventDescription, startTime, endTime}) {
+function RegularEventItem({eventSummery, eventDescription, startTime, endTime, colorHexValue}) {
+    const boxColorHexValue = colorHexValue === undefined ? '#4279d1' : colorHexValue;
+
     return (
         <Row>
             <Col style={{flexGrow: 0}}>
                 <Box
                     sx={{
-                        backgroundColor: '#4279d1'
+                        backgroundColor: boxColorHexValue
                     }}
                     style={{width: "4px", height: "100%"}}
                 />

--- a/src/pages/GenerateCalendar.jsx
+++ b/src/pages/GenerateCalendar.jsx
@@ -21,6 +21,7 @@ import {
 import {useNavigate} from "react-router-dom";
 import {toast} from "react-toastify";
 import {Skeleton} from "@mui/material";
+import RegularEventItem from "../components/RegularEventItem.jsx";
 
 const GenerateCalendar = () => {
     const [startDate, setStartDate] = useState(new Date());
@@ -97,7 +98,7 @@ const GenerateCalendar = () => {
         };
 
         if (isAuthenticated) {
-            fetchStudyPlan()
+            fetchStudyPlan();
         }
     }, [isAuthenticated]);
 
@@ -579,18 +580,12 @@ const GenerateCalendar = () => {
                             ) : (
                                 <>
                                     {upComingSession ? (
-                                        <>
-                                            <h6 className="mb-0 title-in-preferences">Course Name:</h6>
-                                            <p>{upComingSession.courseName}</p>
-                                            <h6 className="mb-0 title-in-preferences">Subject:</h6>
-                                            <p>{upComingSession.description}</p>
-                                            <h6 className="mb-0 title-in-preferences">Start Time:</h6>
-                                            <p>
-                                                {new Date(upComingSession.start.value).toLocaleString()}
-                                            </p>
-                                            <h6 className="mb-0 title-in-preferences">End Time:</h6>
-                                            <p>{new Date(upComingSession.end.value).toLocaleString()}</p>
-                                        </>
+                                        <RegularEventItem
+                                            eventSummery={upComingSession.courseName}
+                                            eventDescription={upComingSession.description}
+                                            startTime={upComingSession.start}
+                                            endTime={upComingSession.end}>
+                                        </RegularEventItem>
                                     ) : (
                                         <div>There are no sessions yet.</div>
                                     )}

--- a/src/pages/GenerateCalendar.jsx
+++ b/src/pages/GenerateCalendar.jsx
@@ -584,7 +584,8 @@ const GenerateCalendar = () => {
                                             eventSummery={upComingSession.courseName}
                                             eventDescription={upComingSession.description}
                                             startTime={upComingSession.start}
-                                            endTime={upComingSession.end}>
+                                            endTime={upComingSession.end}
+                                            colorHexValue={upComingSession.colorHexValue}>
                                         </RegularEventItem>
                                     ) : (
                                         <div>There are no sessions yet.</div>

--- a/src/styles/generateCalendar.css
+++ b/src/styles/generateCalendar.css
@@ -1,83 +1,92 @@
 /* For screens smaller than 768px */
 @media (max-width: 767px) {
-  .date-picker {
-    align-items: center;
-    margin-right: 0;
-  }
+    .date-picker {
+        align-items: center;
+        margin-right: 0;
+    }
 
-  .generate-plan-card {
-    width: 90%;
-    margin: 10px;
-  }
+    .generate-plan-card {
+        width: 90%;
+        margin: 10px;
+    }
 
-  .date-picker-area {
-    padding: 25px;
-    margin: 10px;
-  }
+    .date-picker-area {
+        padding: 25px;
+        margin: 10px;
+    }
 
-  .date-picker-area h2 {
-    font-size: 30px;
-  }
+    .date-picker-area h2 {
+        font-size: 30px;
+    }
 
-  .date-picker-area label {
-    font-size: 16px;
-  }
+    .date-picker-area label {
+        font-size: 16px;
+    }
 }
 
 /* For screens between 768px and 992px */
 @media (min-width: 768px) and (max-width: 991px) {
-  .date-picker {
-    align-items: center;
-    margin-right: 0;
-  }
-  .generate-plan-card {
-    width: 60%;
-    margin: 10px;
-  }
-  .date-picker-area {
-    padding: 25px;
-    margin: 10px;
-  }
-  .date-picker-area h2 {
-    font-size: 30px;
-  }
-  .date-picker-area label {
-    font-size: 16px;
-  }
+    .date-picker {
+        align-items: center;
+        margin-right: 0;
+    }
+
+    .generate-plan-card {
+        width: 60%;
+        margin: 10px;
+    }
+
+    .date-picker-area {
+        padding: 25px;
+        margin: 10px;
+    }
+
+    .date-picker-area h2 {
+        font-size: 30px;
+    }
+
+    .date-picker-area label {
+        font-size: 16px;
+    }
 }
 
 /* For screens between 992px and 1200px */
 @media (min-width: 992px) and (max-width: 1199px) {
-  .generate-plan-card {
-    width: 45%;
-    margin: 10px;
-  }
+    .generate-plan-card {
+        width: 45%;
+        margin: 10px;
+    }
 }
 
 /* For screens larger than 1200px */
 @media (min-width: 1200px) {
-  .date-picker {
-    margin-right: 50px;
-  }
+    .date-picker {
+        margin-right: 50px;
+    }
 }
 
 .google-calendar-icon-btn {
-  border-width: 0;
-  height: 30px;
-  width: 30px;
+    border-width: 0;
+    height: 30px;
+    width: 30px;
 }
 
 .google-calendar-btn {
-  cursor: pointer;
-  margin: 16px 0 16px 0;
-  max-width: 100%;
+    cursor: pointer;
+    margin: 16px 0 16px 0;
+    max-width: 100%;
 }
 
 .card-container.generate-plan-card {
-  margin: 10px auto;
-  width: 100%;
+    margin: 10px auto;
+    width: 100%;
+}
+
+.sub-text {
+    color: gray;
+    font-size: 1rem;
 }
 
 .generated-plan-value {
-  text-align: right;
+    text-align: right;
 }


### PR DESCRIPTION
I've redisigned the upcoming study session area.

- The UI is cleaner
- Added a counter for the number of day away from that session
- Prepared the structure for passing the color of the event of the session (will be implemented in the future). The object `upComingStudySession` will contain a field called `colorHexValue` which will be a string of the format "#aaaaaa". If the field is not included, the default color of the line in the UI is the PlanIT blue.
- Added the ".env" file to gitignore

Before:
<img width="382" alt="צילום מסך 2023-07-29 140824" src="https://github.com/Danielsio/Plan-IT-Web/assets/64507685/5d85fdec-94c3-4613-8e81-0827235cb46f">

After:
<img width="468" alt="צילום מסך 2023-07-29 194217" src="https://github.com/Danielsio/Plan-IT-Web/assets/64507685/f4d5a932-7c99-4a0a-814d-7561d23a99bd">

closes #52 
