### PR TITLE
Fix UI in the generate calendar page

### DIFF
--- a/src/components/generate/Exam.jsx
+++ b/src/components/generate/Exam.jsx
@@ -7,12 +7,7 @@ function ExamItem({courseName, dateTimeISO}) {
 
         <Row style={{marginBottom:"10px"}}>
             <Col style={{flexGrow: 0}}>
-                <Box
-                    sx={{
-                        backgroundColor: "#4279d1"
-                    }}
-                    style={{width: "4px", height: "100%"}}
-                />
+                <Box className="box-event-line"/>
             </Col>
             <Col>
                 <div className="mb-0 title-in-preferences">

--- a/src/components/generate/Exam.jsx
+++ b/src/components/generate/Exam.jsx
@@ -1,18 +1,31 @@
 import React from "react";
 import {Row, Col} from "react-bootstrap";
+import Box from "@mui/material/Box";
 
 function ExamItem({courseName, dateTimeISO}) {
     return (
-        <Row className="mb-2 row-preferences">
-            <Col xs={6}>
-                <h6 className="mb-0 title-in-preferences">{courseName}</h6>
+
+        <Row style={{marginBottom:"10px"}}>
+            <Col style={{flexGrow: 0}}>
+                <Box
+                    sx={{
+                        backgroundColor: "#4279d1"
+                    }}
+                    style={{width: "4px", height: "100%"}}
+                />
             </Col>
-            <Col xs={6}>
-                <h6 className="mb-0 generated-plan-value">
+            <Col>
+                <div className="mb-0 title-in-preferences">
+                    {courseName}
+                </div>
+            </Col>
+            <Col className="generated-plan-value" style={{maxWidth: "fit-content"}}>
+                <div className="sub-text">
                     {new Date(dateTimeISO).toLocaleDateString()}
-                </h6>
+                </div>
             </Col>
         </Row>
+
     );
 }
 

--- a/src/components/generate/SelectDatesAndGenerateCard.jsx
+++ b/src/components/generate/SelectDatesAndGenerateCard.jsx
@@ -7,9 +7,12 @@ const SelectDatesCardComponent = ({startDate, endDate, setStartDate, setEndDate,
     return (
         <Card className="card-container generate-plan-card select-dates-card">
             <Card.Body>
-                <h2>Select the start and end of your study period.</h2>
+                <Card.Title>Generate A New Study Plan</Card.Title>
+
+                <div className="sub-text" style={{marginBottom: "10px"}}>Select the beginning and the end of your study period.
+                    A new study plan will be generated within those boundaries.</div>
                 <div className="mb-3">
-                    <label htmlFor="start-date-picker">Start Date:</label>
+                    <label htmlFor="start-date-picker">Start date:</label>
                     <DatePicker
                         id="start-date-picker"
                         selected={startDate}
@@ -18,7 +21,7 @@ const SelectDatesCardComponent = ({startDate, endDate, setStartDate, setEndDate,
                     />
                 </div>
                 <div className="mb-3">
-                    <label htmlFor="end-date-picker">End Date:</label>
+                    <label htmlFor="end-date-picker">End date:</label>
                     <DatePicker
                         id="end-date-picker"
                         selected={endDate}
@@ -26,8 +29,8 @@ const SelectDatesCardComponent = ({startDate, endDate, setStartDate, setEndDate,
                         className="form-control"
                     />
                 </div>
-                <Button variant="primary" size="lg" onClick={handleGenerate}>
-                    Generate New Plan
+                <Button variant="primary" style={{width: "100%"}} size="lg" onClick={handleGenerate}>
+                    Generate A New Plan
                 </Button>
 
                 {loading && (

--- a/src/components/generate/StudyPlanCard.jsx
+++ b/src/components/generate/StudyPlanCard.jsx
@@ -4,10 +4,17 @@ import ExamItem from './Exam.jsx';
 import {Skeleton} from "@mui/material";
 
 const StudyPlanCard = ({loadingStudyDetails, studyPlan, handleReGenerate}) => {
+    const studyPlanStartTimeAsString = studyPlan ?
+        new Date(studyPlan.startDateTimeOfPlan).toLocaleDateString() :
+        "";
+    const studyPlanEndTimeAsString = studyPlan ?
+        new Date(studyPlan.endDateTimeOfPlan).toLocaleDateString():
+        "";
+
     return (
         <Card className="card-container generate-plan-card">
             <Card.Body>
-                <Card.Title>Generated Study Plan:</Card.Title>
+                <Card.Title>Latest Generated Study Plan:</Card.Title>
 
                 {loadingStudyDetails ? (
                     <>
@@ -30,72 +37,70 @@ const StudyPlanCard = ({loadingStudyDetails, studyPlan, handleReGenerate}) => {
                     <>
                         {studyPlan ? (
                             <>
+                                <div style={{marginBottom:"20px"}}>
+                                    <div>
+                                        <div className="container-of-from-to-plan">
+                                            <div className="sub-text">From:</div>
+                                            <div className="container-of-date-plan">
+                                                {studyPlanStartTimeAsString}
+                                            </div>
+                                        </div>
+
+                                        <div style={{padding:"10px", display:"inline-block", fontWeight:"bold"}}>{"--->"}</div>
+
+                                        <div className="container-of-from-to-plan">
+                                            <div className="sub-text">To:</div>
+                                            <div className="container-of-date-plan">
+                                                {studyPlanEndTimeAsString}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+
+
+
+                                <div style={{marginBottom: "25px"}}>
+                                    <div style={{display: "inline-block", whiteSpace: "break-spaces"}} className="title-in-preferences">
+                                        {studyPlan.totalNumberOfStudySessions}{" "}
+                                    </div>
+                                    <div style={{display: "inline-block"}} className="mb-0">
+                                        study sessions were generated.
+                                    </div>
+
+                                </div>
+
+
+
+                                <hr></hr>
+
                                 {studyPlan ? (
                                     <>
-                                        <div className="title-in-preferences">
-                                            Scanned Exams:{" "}
-                                            <ul>
-                                                {studyPlan.scannedExams.map((exam) => {
-                                                    return (
-                                                        <li key={exam.dateTimeISO}>
-                                                            <ExamItem
-                                                                courseName={exam.courseName}
-                                                                dateTimeISO={exam.dateTimeISO}
-                                                            />
-                                                        </li>
-                                                    );
-                                                })}
-                                            </ul>
-                                        </div>
-                                        <hr></hr>
-                                        <Row className="mb-2 row-preferences">
-                                            <Col xs={6}>
-                                                <h6 className="mb-0 title-in-preferences">
-                                                    Start Date Time of Plan:
-                                                </h6>
-                                            </Col>
-                                            <Col xs={6}>
-                                                <h6 className="mb-0 generated-plan-value">
-                                                    {new Date(
-                                                        studyPlan.startDateTimeOfPlan
-                                                    ).toLocaleDateString()}
-                                                </h6>
-                                            </Col>
-                                        </Row>
-                                        <Row className="mb-2 row-preferences">
-                                            <Col xs={6}>
-                                                <h6 className="mb-0 title-in-preferences">
-                                                    End Date Time of Plan:
-                                                </h6>
-                                            </Col>
-                                            <Col xs={6}>
-                                                <h6 className="mb-0 generated-plan-value">
-                                                    {new Date(
-                                                        studyPlan.endDateTimeOfPlan
-                                                    ).toLocaleDateString()}
-                                                </h6>
-                                            </Col>
-                                        </Row>
-                                        <Row className="mb-2">
-                                            <Col xs={6}>
-                                                <h6 className="mb-0 title-in-preferences">
-                                                    Total Number of Study Sessions:
-                                                </h6>
-                                            </Col>
-                                            <Col xs={6}>
-                                                <h6 className="mb-0 generated-plan-value">
-                                                    {studyPlan.totalNumberOfStudySessions}
-                                                </h6>
-                                            </Col>
-                                        </Row>
+                                        <Card.Title style={{ marginTop: "25px"}}>
+                                            Recognized Exams:{" "}
+                                        </Card.Title>
+                                        <div style={{marginBottom: "25px"}}>
+                                            {studyPlan.scannedExams.map((exam) => {
+                                                return (
+                                                    <ExamItem
+                                                        courseName={exam.courseName}
+                                                        dateTimeISO={exam.dateTimeISO}
+                                                    />
 
+                                                );
+                                            })}
+                                        </div>
+
+                                        <hr></hr>
+
+                                        <Card.Title style={{marginTop: "25px"}}>Any Changes To Your Calendar?</Card.Title>
+                                        <div className="sub-text" style={{marginBottom: "10px"}}>The study plan between {studyPlanStartTimeAsString} and {studyPlanEndTimeAsString} will be refreshed.</div>
                                         <Button
-                                            className="mt-3"
                                             variant="warning"
                                             size="lg"
                                             onClick={handleReGenerate}
                                         >
-                                            Re-Generate Existing Plan
+                                            Re-Generate The Existing Plan
                                         </Button>
                                     </>
                                 ) : (

--- a/src/styles/generateCalendar.css
+++ b/src/styles/generateCalendar.css
@@ -77,6 +77,17 @@
     max-width: 100%;
 }
 
+.container-of-from-to-plan {
+    display: inline-block;
+}
+
+.container-of-date-plan {
+    background-color: #eeeeee;
+    display: inline-block;
+    border-radius: 10px;
+    padding: 10px;
+}
+
 .card-container.generate-plan-card {
     margin: 10px auto;
     width: 100%;
@@ -87,6 +98,17 @@
     font-size: 1rem;
 }
 
+.sub-text-a {
+    color: gray;
+    font-size: 1rem;
+}
+
+.sub-text-b {
+    color: green;
+    font-size: 1rem;
+}
+
 .generated-plan-value {
-    text-align: right;
+    display: flex;
+    align-items: center;
 }

--- a/src/styles/generateCalendar.css
+++ b/src/styles/generateCalendar.css
@@ -98,14 +98,10 @@
     font-size: 1rem;
 }
 
-.sub-text-a {
-    color: gray;
-    font-size: 1rem;
-}
-
-.sub-text-b {
-    color: green;
-    font-size: 1rem;
+.box-event-line {
+    background-color: #4279d1;
+    height: 100%;
+    width: 4px;
 }
 
 .generated-plan-value {


### PR DESCRIPTION
I've made some UI changes in the "Generate Calendar" page.

- The "generate new plan" area
Old:
<img width="210" alt="צילום מסך 2023-08-06 024214" src="https://github.com/Danielsio/Plan-IT-Web/assets/64507685/a557e7c7-13b6-4d57-b395-af1050ec73e4">

New:
<img width="279" alt="צילום מסך 2023-08-08 181635" src="https://github.com/Danielsio/Plan-IT-Web/assets/64507685/d7b59ce9-72f5-4f85-8ef0-9de9a8b71ccc">

- The "latest study plan" area
Old: 
<img width="377" alt="צילום מסך 2023-08-06 033135" src="https://github.com/Danielsio/Plan-IT-Web/assets/64507685/5f6f2a6d-9201-45a5-8aa5-18e5af015b1c">

New:
<img width="389" alt="צילום מסך 2023-08-08 181708" src="https://github.com/Danielsio/Plan-IT-Web/assets/64507685/a569cea1-d768-4c58-a1f8-b68e55bbf0b7">

Closes #70 
Closes #68 