### PR TITLE
Add a button for removing the latest study plan from the user's calendar

### DIFF
--- a/src/components/generate/StudyPlanCard.jsx
+++ b/src/components/generate/StudyPlanCard.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import {Card, Button} from 'react-bootstrap';
+import {Card, Button, Row, Col} from 'react-bootstrap';
 import ExamItem from './Exam.jsx';
-import {Skeleton} from "@mui/material";
+import {IconButton, Menu, Skeleton} from "@mui/material";
+import MenuItem from "@mui/material/MenuItem";
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import * as PropTypes from "prop-types";
 
-const StudyPlanCard = ({loadingStudyDetails, studyPlan, handleReGenerate}) => {
+const StudyPlanCard = ({loadingStudyDetails, studyPlan, handleReGenerate, handleRemoveStudyPlanButtonClick}) => {
     const studyPlanStartTimeAsString = studyPlan ?
         new Date(studyPlan.startDateTimeOfPlan).toLocaleDateString() :
         "";
@@ -11,10 +14,55 @@ const StudyPlanCard = ({loadingStudyDetails, studyPlan, handleReGenerate}) => {
         new Date(studyPlan.endDateTimeOfPlan).toLocaleDateString():
         "";
 
+    const [anchorEl, setAnchorEl] = React.useState(null);
+    const openMoreMenu = Boolean(anchorEl);
+    const handleClickMoreMenu = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleCloseMoreMenu = () => {
+        setAnchorEl(null);
+    };
+
+    function handleRemoveStudyPlanAndCloseMenu() {
+        handleRemoveStudyPlanButtonClick();
+        handleCloseMoreMenu();
+    }
+
     return (
         <Card className="card-container generate-plan-card">
             <Card.Body>
-                <Card.Title>Latest Generated Study Plan:</Card.Title>
+                <Row>
+                    <Col style={{flexGrow: "1"}}>
+                        <Card.Title>Latest Generated Study Plan:</Card.Title>
+                    </Col>
+                    <Col style={{flexGrow: "0"}}>
+                        {studyPlan ? (<div>
+                            <IconButton
+                                id="basic-button"
+                                aria-controls={openMoreMenu ? 'basic-menu' : undefined}
+                                aria-haspopup="true"
+                                aria-expanded={openMoreMenu ? 'true' : undefined}
+                                onClick={handleClickMoreMenu}
+                            >
+                                <MoreVertIcon/>
+                            </IconButton>
+                            <Menu
+                                id="basic-menu"
+                                anchorEl={anchorEl}
+                                open={openMoreMenu}
+                                onClose={handleCloseMoreMenu}
+                                MenuListProps={{
+                                    'aria-labelledby': 'basic-button',
+                                }}
+                            >
+                                <MenuItem onClick={handleRemoveStudyPlanAndCloseMenu}>Remove This Plan</MenuItem>
+                            </Menu>
+                        </div>) : (<div></div>)}
+                    </Col>
+                </Row>
+
+
+
 
                 {loadingStudyDetails ? (
                     <>

--- a/src/pages/GenerateCalendar.jsx
+++ b/src/pages/GenerateCalendar.jsx
@@ -76,7 +76,7 @@ const GenerateCalendar = () => {
                 } else {
                     const problem = error.response.data.details;
                     const status = error.response.status;
-                    if (status === 400 && problem === ERROR_USER_NOT_FOUND) {
+                    if (status === 400 && (problem === ERROR_USER_NOT_FOUND || problem === ERROR_INVALID_GRANT)) {
                         toast.error(
                             <div>
                                 <span>Session has expired, Please Sign-in</span>
@@ -225,7 +225,7 @@ const GenerateCalendar = () => {
                 });
 
             toast.info(
-                "We are creating you study plan. This might take a minute or two.",
+                "We are creating your study plan. This might take a minute or two.",
                 {autoClose: false}
             );
         }
@@ -316,9 +316,63 @@ const GenerateCalendar = () => {
             });
 
         toast.info(
-            "We are creating you study plan. This might take a minute or two.",
+            "We are creating your study plan. This might take a minute or two.",
             {autoClose: false}
         );
+    };
+
+    const handleRemoveStudyPlan = async () => {
+        toast.info(
+            "We are removing the latest study plan. This might take a minute or two.",
+            {autoClose: false}
+        );
+        try {
+            setLoadingStudyDetails(true);
+            const response = await api.delete("/study-plan", {
+                params: {
+                    sub: subjectID,
+                },
+            });
+            dismissAllToastMessages();
+            console.log(response.data);
+
+            toast.success(`The latest study plan between ${new Date(studyPlan.startDateTimeOfPlan).toLocaleDateString()} and ${new Date(studyPlan.endDateTimeOfPlan).toLocaleDateString()}
+            was successfully removed from your Google Calendar.`)
+            setStudyPlan(null);
+            setUpComingSession(null);
+            setLoadingStudyDetails(false);
+        } catch (error) {
+            dismissAllToastMessages();
+            console.error(error);
+
+            if (error.code === ERROR_COULD_NOT_CONNECT_TO_SERVER_CODE) {
+                toast.error(
+                    "Service Unavailable. It looks that we have some problems right now. Please try again later."
+                );
+            } else {
+                const problem = error.response.data.details;
+                const status = error.response.status;
+                if (status === 400 && (problem === ERROR_USER_NOT_FOUND || problem === ERROR_INVALID_GRANT)) {
+                    toast.error(
+                        <div>
+                            <span>Session has expired, Please Sign-in</span>
+                            <Button
+                                className="google-calendar-btn col-lg-3 mt-3 btn-grey-planit"
+                                variant="secondary"
+                                size="lg"
+                                onClick={clearStateAndRedirect}
+                            >
+                                Go to Home
+                            </Button>
+                        </div>
+                    );
+                } else {
+                    toast.error(
+                        "Service Unavailable. It looks that we have some problems right now. Please try again later."
+                    );
+                }
+            }
+        }
     };
 
     const handleOpenCalendar = () => {
@@ -434,7 +488,7 @@ const GenerateCalendar = () => {
             });
 
         toast.info(
-            "We are creating you study plan. This might take a minute or two.",
+            "We are creating your study plan. This might take a minute or two.",
             {autoClose: false}
         );
     };
@@ -464,6 +518,7 @@ const GenerateCalendar = () => {
                         loadingStudyDetails={loadingStudyDetails}
                         studyPlan={studyPlan}
                         handleReGenerate={handleReGenerate}
+                        handleRemoveStudyPlanButtonClick={handleRemoveStudyPlan}
                     />
                     <UpcomingStudySessionCard
                         loadingStudyDetails={loadingStudyDetails}


### PR DESCRIPTION
I've added a new "More" menu button to the "Generated Study Plan" area.
It looks like that:
<img width="348" alt="צילום מסך 2023-08-27 023540" src="https://github.com/itayf9/Plan_It_Enigne/assets/64507685/492807d7-a74f-44f4-93b2-b4498b6a859e">

When you click on it, a menu is opened.
It reveals a new "Remove this plan" menu item.
It looks like this:
<img width="455" alt="צילום מסך 2023-08-27 023611" src="https://github.com/itayf9/Plan_It_Enigne/assets/64507685/a8a6b211-50cd-4a3b-affc-cea15f2410b4">

The new button invokes DELETE `/study-plan` and expects to recieve a simple `DTOstatus` object.

Closes #88 